### PR TITLE
fix: tiny errors caused by precision

### DIFF
--- a/bytepiece/faster.pyx
+++ b/bytepiece/faster.pyx
@@ -4,7 +4,7 @@ from libc.math cimport INFINITY
 
 def _tokenize(self, bytes text):
     cdef int e, k, s
-    cdef float v, score
+    cdef double v, score
     cdef list routes = [(0, None)] + [(-INFINITY, None) for _ in text]
     cdef list tokens = []
     for e, (k, v) in self._automaton.iter(text):


### PR DESCRIPTION
不知道这是不是个小bug，应该是cython精度导致的。
比如
text = '''第20章 头的故事


'''
这个后面的回车会编码成260, 13，正常应该13, 260。