### PR TITLE
Update README.md，示例里面tokenizer1.convert_to_sentencepiece在0.6.1版本是不工作的。

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install Cython
 ```
 安装完之后，就可以用pip安装BytePiece了：
 ```bash
-pip install bytepiece==0.6.1
+pip install bytepiece==0.6.2
 ```
 
 ## 使用


### PR DESCRIPTION
示例里面tokenizer1.convert_to_sentencepiece在0.6.1版本是不工作的。