### PR TITLE
修正安装时UnicodeDecodeError错误

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version='0.6.3',
     python_requires='>=3',
     description='Smarter Byte-based Tokenizer',
-    long_description=open('README_en.md').read(),
+    long_description=open('README_en.md',encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     license='Apache License 2.0',
     url='https://github.com/bojone/bytepiece',


### PR DESCRIPTION
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "F:\Code\BytePiece\setup.py", line 11, in <module>
          long_description=open('README_en.md').read(),
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 7: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed